### PR TITLE
Add skip link and smooth scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><radialGradient id="g" cx="50%" cy="50%" r="60%"><stop offset="0%" stop-color="%2300F0FF"/><stop offset="50%" stop-color="%237B6CFF"/><stop offset="100%" stop-color="%23070a13"/></radialGradient></defs><circle cx="50" cy="50" r="46" fill="url(%23g)"/><path d="M50 18 L76 50 L50 82 L24 50 Z" fill="none" stroke="white" stroke-width="3" opacity=".7"/></svg>' />
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to main content</a>
   <div class="noise" aria-hidden="true"></div>
   <nav class="nav" aria-label="Primary">
     <div class="nav__brand">
@@ -54,7 +55,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main">
     <section class="about" id="about" aria-label="About the author">
       <div class="section__hd">
         <h2>Author</h2>

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,8 @@
 
 *{box-sizing:border-box}
 html,body{height:100%}
+html{scroll-behavior:smooth}
+section{scroll-margin-top:80px}
 body{
   margin:0; color:var(--fg);
   font:16px/1.6 Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -31,6 +33,21 @@ body{
     radial-gradient(1000px 800px at 30% 120%, rgba(0,255,163,.12), transparent 60%),
     linear-gradient(180deg, #05070d 0%, #0a0f1b 100%);
   overflow-x:hidden;
+}
+
+/* Skip link */
+.skip-link{
+  position:absolute;
+  top:-40px;left:0;
+  background:var(--glass);
+  color:var(--fg);
+  padding:8px 12px;
+  border:1px solid var(--stroke);
+  border-radius:var(--radius);
+}
+.skip-link:focus{
+  top:10px;
+  z-index:10;
 }
 
 /* subtle film grain */


### PR DESCRIPTION
## Summary
- Add skip to main content link for keyboard users
- Enable smooth scrolling and offset section anchors for sticky nav
- Style skip link using existing design tokens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c59b37e3c88328963ec1b828656479